### PR TITLE
Improve cutscene skip

### DIFF
--- a/src/Dialogue.py
+++ b/src/Dialogue.py
@@ -2,10 +2,8 @@ def dialogue(rom, flags):
 
     if flags['CutDialogue']:
         print('Supressing most dialogue')
-        rom.write_to_rom(0x08092F84, [0x4770]) # Text box
-        rom.write_to_rom(0x08092C40, [0x4770]) # Yes/No (?)
-        rom.write_to_rom(0x08091C7C, [0x4770]) # Yes/No (?)
-        rom.write_to_rom(0x080931ec, [0x4770]) # Multiple text boxes
+        # Cutscene skip function: jump over keypad and debug mode checks
+        rom.write_to_rom(0x080915F2, [0xE014])
     else:
         rom.write_to_rom(0x08890800, [0x4770])
         


### PR DESCRIPTION
Replaces the cutscene skip logic with the "no cutscene patch" logic. This makes the cutscenes much faster. It also brings back the yes/no prompts, but this is a good thing due to the Colosso tutorials.